### PR TITLE
在 WSL 运行 VS Code 时提示需要 libX11-xcb.so.1

### DIFF
--- a/docs/4-Advanced/4-1-GUI.md
+++ b/docs/4-Advanced/4-1-GUI.md
@@ -3,7 +3,7 @@
 # GUI 图形化窗口
 
 > 虽然上面的方案有时候能够解决问题，但是最为深度整合的方案是：在 WSL 侧的 Linux 环境下安装 VSCode 并从 Linux 侧打开，这样就一定能保证 VSCode 使用的工具链全部是 WSL 侧工具链了。
-> 
+>
 > 方案：安装一个 XServer 来让 Linux 侧 GUI 程序有窗口显示。
 
 ## 安装 XServer for windows
@@ -52,3 +52,7 @@ sudo apt install code
 ```
 
 - 打开 XServer 窗口，在 WSL 终端执行 `code`，应该就可以看到 WSL 中的 VSCode 窗口启动了。
+
+有可能还需要安装 ``libx11-xcb1``. 安装即可:
+
+![vscode-libx11-xcb1.png](https://i.loli.net/2019/04/05/5ca705028ca16.png)


### PR DESCRIPTION
🚀 **我这里解决了这些问题：**

按照原文描述安装 WSL 下的图形界面成功， 但是运行 VS Code 时提示需要 libX11-xcb.so.1。
于是添加了这一提示。

💡 **我这次对这些地方做出了更改：**

`/docs/4-Advanced/4-1-GUI.md` 添加了上述提示以及一张图片：

![vscode-libx11-xcb1.png](https://i.loli.net/2019/04/05/5ca705028ca16.png)