### PR TITLE
Fix the description of the owner of APT

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 WSL 的出现似乎缓解了这些烦恼。WSL —— Windows Subsystem for Linux，即适用于 Linux 的 Windows 子系统。在 2019 年的夏天，微软官方推出了 [WSL 2：基于最新虚拟化技术的 WSL 引擎。](https://docs.microsoft.com/en-us/windows/wsl/wsl2-about)强大的 WSL 2 直接将一个 Linux 内核放入 WSL 架构中，使得 Linux 子系统的 I/O 效率急速提升，也让 Linux 子系统能真正执行「全部 Linux 原生的系统调用（Full System Call Compatibility）」。无论是 WSL 还是 WSL 2，我们都可以借助之来给我们的 Windows 配置一个美观可用的 **学习编程的开发环境**，包括：
 
 - 原汁原味 Unix 风格的终端环境和开发环境
-- 一行命令管理所有软件包的 APT 包管理工具（Ubuntu's Advanced Packaging Tool）
+- 一行命令管理所有软件包的 APT 包管理工具（Debian's Advanced Packaging Tool）
 - 在 Visual Studio Code 中直接编写、开发、调试你的项目
 
 如果你对这些内容感兴趣，那么 [**直接进入文档**](https://dowww.spencerwoo.com/)，放飞自我，尽情折腾。\\(￣︶￣*\\))

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ footer: 2018 - 2020 ©Spencer Woo. Released under the CC BY-NC-SA 4.0 Internatio
 WSL 的出现似乎缓解了这些烦恼。WSL —— Windows Subsystem for Linux，即适用于 Linux 的 Windows 子系统。在 2019 年的夏天，微软官方推出了 [WSL 2：基于最新虚拟化技术的 WSL 引擎。](https://docs.microsoft.com/en-us/windows/wsl/wsl2-about)强大的 WSL 2 直接将一个 Linux 内核放入 WSL 架构中，使得 Linux 子系统的 I/O 效率急速提升，也让 Linux 子系统能真正执行「全部 Linux 原生的系统调用（Full System Call Compatibility）」。无论是 WSL 还是 WSL 2，我们都可以借助之来给我们的 Windows 配置一个美观可用的 **学习编程的开发环境**，包括：
 
 - 原汁原味 Unix 风格的终端环境和开发环境
-- 一行命令管理所有软件包的 APT 包管理工具（Ubuntu's Advanced Packaging Tool）
+- 一行命令管理所有软件包的 APT 包管理工具（Debian's Advanced Packaging Tool）
 - 在 Visual Studio Code 中直接编写、开发、调试你的项目
 
 如果你对这些内容感兴趣，那么 [**直接进入文档**](https://dowww.spencerwoo.com/)，放飞自我，尽情折腾。\\(￣︶￣*\\))

--- a/docs/dev/2-cli/2-0-intro.md
+++ b/docs/dev/2-cli/2-0-intro.md
@@ -25,7 +25,7 @@
 
 - Terminal 工具：Windows Terminal、Fluent Terminal、Hyper、Terminus……
 - Shell 环境：`bash`、`zsh`、`fish`……
-- Ubuntu 包管理工具：`apt` - Ubuntu's Advanced Packaging Tool
+- Ubuntu 中的包管理工具：`apt` - Debian's Advanced Packaging Tool
 - 版本控制工具：Git
 - 远程登陆工具：SSH - Secure Shell、Mosh - the mobile shell
 - Windows 和 WSL 文件互访的方法

--- a/docs/dev/2-cli/2-2-shell.md
+++ b/docs/dev/2-cli/2-2-shell.md
@@ -43,7 +43,7 @@ sudo apt update && sudo apt upgrade
 
 ## APT
 
-APT - Ubuntu's Advanced Packaging Tool 是 Ubuntu 默认包管理工具。使用 Ubuntu 等 Linux 发行版时，我们往往都会使用 APT 等相似的包管理工具来安装、更新我们的软件包。命令 `apt` 和 `apt-get` 与 APT 不同，它们是用来和 APT 进行交互的高层命令执行工具。请大家清楚二者的区别。
+APT - Debian's Advanced Packaging Tool 是 Ubuntu 默认包管理工具，它是由 Debian 社区开发的。使用 Ubuntu 等基于 Debian 的 Linux 发行版时，我们往往都会使用 APT 等相似的包管理工具来安装、更新我们的软件包。命令 `apt` 和 `apt-get` 与 APT 不同，它们是用来和 APT 进行交互的高层命令执行工具。请大家清楚二者的区别。
 
 其中，在 Ubuntu 16.04 中 Ubuntu 引入了 `apt` 命令来代替曾经老用户熟悉的 `apt-get`，提供了更用户友好的操作和命令行界面，对软件包 cache 缓存的处理也更为优雅。这里我推荐大家使用 `apt` 命令来与 APT 包管理工具交互，安装、管理和更新软件和依赖，接下来的文档中，我也都会使用 `apt` 命令进行介绍。
 
@@ -117,7 +117,7 @@ chsh -s $(which zsh)
 
 ### 安装 fish
 
-同样使用 Ubuntu 包管理工具安装 `fish`：
+同样使用 Ubuntu 中的包管理工具安装 `fish`：
 
 ```bash
 sudo apt install fish

--- a/docs/dev/2-cli/2-3-others.md
+++ b/docs/dev/2-cli/2-3-others.md
@@ -66,7 +66,7 @@ alias myip="curl cip.cc"
 
 Git 是目前版本控制工具的典范、代表，如果你使用 GitHub，那么我相信你已经非常了解 Git 及其使用原理和方法了。
 
-使用 Ubuntu 的 apt 安装 Git：
+使用 Ubuntu 中的 apt 安装 Git：
 
 ```bash
 sudo apt install git


### PR DESCRIPTION
APT is mainly developed and maintained by Debian.
[https://en.wikipedia.org/wiki/APT_(software)](https://en.wikipedia.org/wiki/APT_(software))

APT 主要是由 Debian 开发和维护的，Ubuntu 是一个基于 Debian 的发行版。

🚀 **我这里解决了这些问题：**

1. APT 主要是由 Debian 开发和维护的，Ubuntu 是一个基于 Debian 的发行版，因此项目 README 这里描述有些问题。

💡 **我这次对这些地方做出了更改：**

1. 项目 README

还没有看到其他地方关于 APT 的会令人有疑惑的描述，如果有也会一并修改
